### PR TITLE
Allow comparison against nodesets.

### DIFF
--- a/equivalent-xml.gemspec
+++ b/equivalent-xml.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{equivalent-xml}
-  s.version = "0.2.7"
+  s.version = "0.2.8"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Michael B. Klein"]

--- a/spec/equivalent-xml_spec.rb
+++ b/spec/equivalent-xml_spec.rb
@@ -137,4 +137,13 @@ describe EquivalentXml do
     doc1.should_not be_equivalent_to(doc2)
   end
 
+  it "should compare nodesets" do
+    doc1 = Nokogiri::XML("<doc xmlns='foo:bar'><first>foo  bar baz</first><second>things</second></doc>")
+    doc1.root.children.should be_equivalent_to(doc1.root.children)
+  end
+  
+  it "should compare nodeset with string" do
+    doc1 = Nokogiri::XML("<doc xmlns='foo:bar'><first>foo  bar baz</first><second>things</second></doc>")
+    doc1.root.children.should be_equivalent_to("<first xmlns='foo:bar'>foo  bar baz</first><second xmlns='foo:bar'>things</second>")
+  end
 end


### PR DESCRIPTION
RDF typically creates XML Literals from NodeSets, not Nodes. This is a simple change to allow comparison against NodeSets as well as Nodes.
