### PR TITLE
Patch 1

### DIFF
--- a/lib/equivalent-xml/rspec_matchers.rb
+++ b/lib/equivalent-xml/rspec_matchers.rb
@@ -1,5 +1,10 @@
 require 'equivalent-xml'
 
+begin
+  require 'rspec-expectations'
+rescue LoadError
+end
+
 module EquivalentXml::RSpecMatchers
 
   if defined?(::RSpec)


### PR DESCRIPTION
Here's a pull to fix compatibility with rspec 2.7 & 2.8.  Without this I get:

rake aborted!
uninitialized constant RSpec::Matchers
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/equivalent-xml-0.2.8/lib/equivalent-xml/rspec_matchers.rb:10
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/equivalent-xml-0.2.8/lib/equivalent-xml.rb:175
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in `require'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:68:in`require'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in `each'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:66:in`require'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in `each'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler/runtime.rb:55:in`require'
/Users/justin/.rvm/gems/ree-1.8.7-2011.03@gamma/gems/bundler-1.0.21/lib/bundler.rb:122:in `require'
/Users/justin/workspace/gamma/config/application.rb:7

I believe it is because rspec-expectations is a transitive dependency (not declared explicitly) in Gemfile
