### PR TITLE
Ensure ::X::Matchers namespace is defined before adding matchers

### DIFF
--- a/lib/equivalent-xml/rspec_matchers.rb
+++ b/lib/equivalent-xml/rspec_matchers.rb
@@ -7,9 +7,9 @@ end
 
 module EquivalentXml::RSpecMatchers
 
-  if defined?(::RSpec)
+  if defined?(::RSpec::Matchers)
     rspec_namespace = ::RSpec::Matchers
-  elsif defined?(::Spec)
+  elsif defined?(::Spec::Matchers)
     rspec_namespace = ::Spec::Matchers
   else
     raise NameError, "Cannot find Spec (rspec 1.x) or RSpec (rspec 2.x)"


### PR DESCRIPTION
Needed to make this change because we're using RSpec 1.x (which uses Spec namespace) but other gems we're using (Timewarp specifically) defined the RSpec namespace without regard for that, thus RSpec was defined, but RSpec::Matchers wasn't.
