### PR TITLE
Provides option to :ignore_content in equivalence checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ considered equivalent.
 Don't normalize whitespace within text nodes; require text nodes to 
 match exactly.
 
+    :ignore_content => ["Device > SerialNumber", "Device > ICCID"]
+
+A single CSS selector, or an array of CSS selectors, of nodes for which the content (text and child
+nodes) should be ignored when comparing for equivalence.  Defaults to `nil`.  (Uses Nokogiri's
+`Node#css(*rules)` to conduct the search.)
+
 ### Using with RSpec
 
 EquivalentXml includes a custom matcher for RSpec (version >=1.2.4) that makes including XML
@@ -85,6 +91,7 @@ Chained modifiers:
     node_1.should be_equivalent_to(node_2).respecting_element_order
     node_1.should be_equivalent_to(node_2).with_whitespace_intact
     node_1.should be_equivalent_to(node_2).respecting_element_order.with_whitespace_intact
+    node_1.should be_equivalent_to(node_2).ignoring_content_of("SerialNumber")
 
 ## Contributing to equivalent-xml
  

--- a/lib/equivalent-xml/rspec_matchers.rb
+++ b/lib/equivalent-xml/rspec_matchers.rb
@@ -22,6 +22,7 @@ module EquivalentXml::RSpecMatchers
   #   node.should be_equivalent_to(other_node).respecting_element_order
   #   node.should be_equivalent_to(other_node).with_whitespace_intact
   #   node.should be_equivalent_to(other_node).respecting_element_order.with_whitespace_intact
+  #   node.should be_equivalent_to(other_node).ignoring_content_of("Device > SerialNumber")
   def be_equivalent_to(expected)
     # Placeholder method for documentation purposes; the actual
     # method is defined using RSpec's matcher DSL.
@@ -39,6 +40,10 @@ module EquivalentXml::RSpecMatchers
   
     chain :with_whitespace_intact do
       @opts[:normalize_whitespace] = false
+    end
+
+    chain :ignoring_content_of do |paths|
+      @opts[:ignore_content] = paths
     end
   
     failure_message_for_should do |actual|


### PR DESCRIPTION
Using the `:ignore_content` option, you may provide one or more CSS selectors of nodes for which the content should be ignored when checking for equivalence.

For example, consider my list of devices and Sally's:

Mine:

```
    <Devices>
      <Device>
        <Name>iPhone</Name>
        <ModelNumber>5</ModelNumber>
        <SerialNumber>1234</SerialNumber>
      </Device>
    </Devices>
```

Sally's:

```
    <Devices>
      <Device>
        <Name>iPhone</Name>
        <ModelNumber>5</ModelNumber>
        <SerialNumber>5678</SerialNumber>
      </Device>
    </Devices>
```

By ignoring the `SerialNumber`, I am able to determine that we have the same list of devices, since for this purpose I don't care about a match on the `SerialNumber`.

```
EquivalentXml.equivalent?(mine, sallys)
# => false

EquivalentXml.equivalent?(mine, sallys, :ignore_content => "SerialNumber")
# => true

# Rspec
mine.should be_equivalent_to(sallys).ignoring_content_of("SerialNumber")
```

I'm pretty happy with the functionality of this, but I'm open to better suggestions for the option name... what do you think?
