### PR TITLE
Added test "It is able to ignore nodes with xmlns attribute set"

### DIFF
--- a/lib/equivalent-xml.rb
+++ b/lib/equivalent-xml.rb
@@ -185,7 +185,7 @@ module EquivalentXml
       return false if ignore_list.empty?
 
       ignore_list.each do |selector|
-        return true if node.document.css(selector).include?(node)
+        return true if node.document.search(selector).include?(node)
       end
 
       return false

--- a/spec/equivalent-xml_spec.rb
+++ b/spec/equivalent-xml_spec.rb
@@ -197,6 +197,12 @@ describe EquivalentXml do
 
       doc1.should be_equivalent_to(doc2).ignoring_content_of("SerialNumber")
     end
+    
+    it "is able to ignore nodes with xmlns attribute set" do
+      doc1 = Nokogiri::XML('<a xmlns=""></a>')
+      doc2 = Nokogiri::XML('<a xmlns=""></a>')
+      doc1.should be_equivalent_to(doc2).ignoring_content_of("a")
+    end
   end
 
   context "with the :ignore_content_paths option set to an array of CSS selectors" do

--- a/spec/equivalent-xml_spec.rb
+++ b/spec/equivalent-xml_spec.rb
@@ -201,7 +201,7 @@ describe EquivalentXml do
     it "is able to ignore nodes with xmlns attribute set" do
       doc1 = Nokogiri::XML('<a xmlns=""></a>')
       doc2 = Nokogiri::XML('<a xmlns=""></a>')
-      doc1.should be_equivalent_to(doc2).ignoring_content_of("a")
+      doc1.should be_equivalent_to(doc2).ignoring_content_of("//a")
     end
   end
 


### PR DESCRIPTION
When I compare two nodes which have set "xmlns" attribute,
and ignoring them,
they should be equal.
