### PR TITLE
Updating rspec_matchers for Rspec 2 or 3

### DIFF
--- a/lib/equivalent-xml/rspec_matchers.rb
+++ b/lib/equivalent-xml/rspec_matchers.rb
@@ -1,7 +1,7 @@
 require 'equivalent-xml'
 
 begin
-  require 'rspec-expectations'
+  require 'rspec/expectations'
 rescue LoadError
 end
 


### PR DESCRIPTION
See [rspec-expectations gem v2.99.0 tag, lib/rspec-expectations.rb](https://github.com/rspec/rspec-expectations/blob/v2.99.0/lib/rspec-expectations.rb#L3-L6).

Closes mbklein/equivalent-xml#17
