### PR TITLE
changed rspec method names to remove deprecation warnings

### DIFF
--- a/lib/equivalent-xml/rspec_matchers.rb
+++ b/lib/equivalent-xml/rspec_matchers.rb
@@ -53,10 +53,12 @@ module EquivalentXml::RSpecMatchers
     failure_message do |actual|
       [ 'expected:', expected.to_s, 'got:', actual.to_s ].join("\n")
     end
+    alias failure_message_for_should failure_message
 
     failure_message_when_negated do |actual|
       [ 'expected:', actual.to_s, 'not to be equivalent to:', expected.to_s ].join("\n")
     end
+    alias negative_failure_message failure_message_when_negated
   end
 
 end


### PR DESCRIPTION
This fixes these deprecation warnings:

```
Deprecation Warnings:

`failure_message_for_should_not` is deprecated. Use `failure_message_when_negated` instead. Called from /Users/seandevine/Projects/federatedfreightways/equivalent-xml/lib/equivalent-xml/rspec_matchers.rb:57:in `block in <module:RSpecMatchers>'.

`failure_message_for_should` is deprecated. Use `failure_message` instead. Called from /Users/seandevine/Projects/federatedfreightways/equivalent-xml/lib/equivalent-xml/rspec_matchers.rb:53:in `block in <module:RSpecMatchers>'.
```
