### PR TITLE
Allow to compare XML-Fragments in Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Chained modifiers:
 
 ## History
 
+- <b>0.4.4</b> - Allow to compare XML-Fragments in Strings
 - <b>0.4.3</b> - Updates for rspec 3
 - <b>0.4.2</b> - Move version back into gemspec for now
 - <b>0.4.1</b> - Improved RSpec version checking (contrib. by elandesign)

--- a/equivalent-xml.gemspec
+++ b/equivalent-xml.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = %q{equivalent-xml}
-  s.version = '0.4.3'
+  s.version = '0.4.4'
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Michael B. Klein"]

--- a/lib/equivalent-xml.rb
+++ b/lib/equivalent-xml.rb
@@ -156,8 +156,8 @@ module EquivalentXml
       if data.respond_to?(:node_type)
         return data
       else
-        result = Nokogiri::XML(data)
-        if result.root.nil?
+        result = Nokogiri::XML.fragment(data)
+        if result.respond_to?(:root) && result.root.nil?
           return data
         else
           return result

--- a/spec/equivalent-xml_spec.rb
+++ b/spec/equivalent-xml_spec.rb
@@ -216,4 +216,13 @@ describe EquivalentXml do
       expect(doc1).to be_equivalent_to(doc2).ignoring_attr_values
     end
   end
+
+  context "(on fragments consisting of multiple nodes)" do
+    it "should compare all nodes" do
+      doc1 = "<h1>Headline</h1><h1>Headline</h1>"
+      doc2 = "<h1>Headline</h1><h2>Headline2</h2>"
+      expect(doc1).not_to be_equivalent_to(doc2)
+    end
+  end
+
 end


### PR DESCRIPTION
Hi, 

I found an issue when comparing Strings with NodeLists like "&lt;h1>Headline&lt;/h1>&lt;h1>Headline&lt;/h1>"
and "&lt;h1>Headline&lt;/h1>&lt;h2>Headline2&lt;/h2>". Everything after the first tag got ignored.

The new spec (in this patch) demonstrates the issue. This patch is a simple fix by utilizing Nokogiris Fragment-Parsing.
