### PR TITLE
add test for excluding dashed attributes

### DIFF
--- a/spec/nokogiri_spec.rb
+++ b/spec/nokogiri_spec.rb
@@ -238,6 +238,12 @@ describe "EquivalentXml (Nokogiri)" do
       doc2 = Nokogiri::XML("<doc xmlns='foo:bar'><first order='2' status='off' changed='no'>foo  bar baz</first><second>things</second></doc>")
       expect(doc1).to be_equivalent_to(doc2).ignoring_attr_values( 'order', 'status' )
     end
+
+    it 'works with dashed attributes' do
+      doc1 = Nokogiri::XML("<input class='btn btn-default' name='commit' type='submit' value='Create User'/>")
+      doc2 = Nokogiri::XML("<input class='btn btn-default' data-disable-with='Create User' name='commit' type='submit' value='Create User'/>")
+      expect(doc1).to be_equivalent_to(doc2).ignoring_attr_values( 'data-disable-with' )
+    end
   end
 
   context "(on fragments consisting of multiple nodes)" do

--- a/spec/oga_spec.rb
+++ b/spec/oga_spec.rb
@@ -239,6 +239,12 @@ describe "EquivalentXml (Oga)" do
       doc2 = Oga.parse_xml("<doc xmlns='foo:bar'><first order='2' status='off' changed='no'>foo  bar baz</first><second>things</second></doc>")
       expect(doc1).to be_equivalent_to(doc2).ignoring_attr_values( 'order', 'status' )
     end
+
+    it 'works with dashed attributes' do
+      doc1 = Oga.parse_xml("<input class='btn btn-default' name='commit' type='submit' value='Create User'/>")
+      doc2 = Oga.parse_xml("<input class='btn btn-default' data-disable-with='Create User' name='commit' type='submit' value='Create User'/>")
+      expect(doc1).to be_equivalent_to(doc2).ignoring_attr_values( 'data-disable-with' )
+    end
   end
 
   context "(on fragments consisting of multiple nodes)" do


### PR DESCRIPTION
While working on https://github.com/bootstrap-ruby/rails-bootstrap-forms/pull/278, I found that excluding attributes with dashes does not work.