### PR TITLE
Explicitly require dependencies to avoid ordering issues

### DIFF
--- a/lib/equivalent-xml.rb
+++ b/lib/equivalent-xml.rb
@@ -1,5 +1,6 @@
 require 'equivalent-xml/node_type'
-Dir[File.expand_path('../equivalent-xml/proxy/*',__FILE__)].each { |file| require file }
+require 'equivalent-xml/proxy/nokogiri'
+require 'equivalent-xml/proxy/oga'
 
 module EquivalentXml
   class << self

--- a/lib/equivalent-xml/proxy/nokogiri.rb
+++ b/lib/equivalent-xml/proxy/nokogiri.rb
@@ -1,3 +1,5 @@
+require 'equivalent-xml/proxy/base'
+
 module EquivalentXml
   module Proxy
     class Nokogiri < Base

--- a/lib/equivalent-xml/proxy/oga.rb
+++ b/lib/equivalent-xml/proxy/oga.rb
@@ -1,3 +1,5 @@
+require 'equivalent-xml/proxy/base'
+
 module EquivalentXml
   module Proxy
     class Oga < Base


### PR DESCRIPTION
I ran into an issue attempting to use the master version (which fixes a comparison bug we were having in 0.6.0) where the order of files being loaded in `lib/equivalent-xml.rb` was inconsistent. This leads to an issue when requiring the gem:

```
Bundler::GemRequireError: There was an error while trying to load the gem 'equivalent-xml'.
Gem Load Error is: uninitialized constant EquivalentXml::Proxy::Base
```

`Dir[File.expand_path('../equivalent-xml/proxy/*',__FILE__)]` seems to return an array of paths in an unintended order. This causes the subclasses to load before the super class, which results
in EquivalentXml::Proxy::Base being undefined.

On my machine it will load in the order:
```
equivalent-xml/lib/equivalent-xml/proxy/oga.rb
equivalent-xml/lib/equivalent-xml/proxy/nokogiri.rb
equivalent-xml/lib/equivalent-xml/proxy/base.rb
```

I've changed the requires to be more explicit, each subclass now requires the base class, and `lib/equivalent-xml.rb` requires each of the subclasses. It's possible you're not keen on this approach, but I thought I would propose it to see what you thought.